### PR TITLE
Add timer progress indicator and conditional Save button

### DIFF
--- a/Pomodoro Timer App/ViewModels/SettingsViewModel.swift
+++ b/Pomodoro Timer App/ViewModels/SettingsViewModel.swift
@@ -111,6 +111,24 @@ class SettingsViewModel: ObservableObject {
         )
     }
 
+    var hasChanges: Bool {
+        tempRounds != timerManager.timer.originalRounds ||
+        tempFocusSessionMinutes != timerManager.timer.originalMinutes ||
+        tempShortBreakMinutes != timerManager.timer.originalBreakMinutes ||
+        tempLongBreakMinutes != timerManager.timer.originalLongBreakMinutes ||
+        tempLongBreakInterval != timerManager.longBreakInterval ||
+        tempAutoStartBreaks != timerManager.autoStartBreaks ||
+        tempAutoStartFocus != timerManager.autoStartFocus ||
+        tempCompletionSound != timerManager.completionSound ||
+        tempHapticFeedback != timerManager.hapticFeedbackEnabled ||
+        tempDailyGoal != DailyStatsManager.shared.dailyGoal ||
+        tempPreventDisplaySleep != UIApplication.shared.isIdleTimerDisabled ||
+        tempFocusEmoji != focusEmoji ||
+        tempBreakEmoji != breakEmoji ||
+        tempLongBreakEmoji != longBreakEmoji ||
+        tempColorMode != colorMode
+    }
+
     var isDefaults: Bool {
         tempRounds == 4 &&
         tempFocusSessionMinutes == 25 &&

--- a/Pomodoro Timer App/ViewModels/TimerManager.swift
+++ b/Pomodoro Timer App/ViewModels/TimerManager.swift
@@ -19,6 +19,7 @@ class TimerManager: TimerManagerProtocol, ObservableObject {
     @Published var sessionCompleted = false
     @Published var hideTimerButtons = false
     @Published var isFocusInterval = true
+    @Published var progress: Float = 0
     var autoStartBreaks = true
     var autoStartFocus = true
     var completionSound: SoundManager.CompletionSound = .chime
@@ -48,7 +49,9 @@ class TimerManager: TimerManagerProtocol, ObservableObject {
         } else {
             remainingSeconds = (timer.minutes * 60) + timer.seconds
         }
-        totalTimeInSeconds = remainingSeconds
+        if !isResuming {
+            totalTimeInSeconds = remainingSeconds
+        }
         endDate = Date.now.addingTimeInterval(TimeInterval(remainingSeconds))
 
         backgroundTaskManager.beginBackgroundTask()
@@ -137,6 +140,7 @@ class TimerManager: TimerManagerProtocol, ObservableObject {
         timer.seconds = timer.originalSeconds
         completedRounds = 0
         completedBreaks = 0
+        progress = 0
         totalTimeInSeconds = (timer.minutes * 60) + timer.seconds
         activityManager.setTimer(
             minutes: timer.minutes,
@@ -165,7 +169,7 @@ class TimerManager: TimerManagerProtocol, ObservableObject {
             return
         }
 
-        let progress = calculateProgress()
+        self.progress = calculateProgress()
         activityManager.setTimer(
             minutes: timer.minutes,
             seconds: timer.seconds,
@@ -262,16 +266,19 @@ class TimerManager: TimerManagerProtocol, ObservableObject {
     }
 
     func resetTimerForNextRound() {
+        progress = 0
         timer.minutes = timer.originalMinutes
         timer.seconds = timer.originalSeconds
     }
 
     func resetTimerForBreak() {
+        progress = 0
         timer.minutes = timer.originalBreakMinutes
         timer.seconds = timer.originalBreakSeconds
     }
 
     func resetTimerForLongBreak() {
+        progress = 0
         timer.minutes = timer.originalLongBreakMinutes
         timer.seconds = timer.originalLongBreakSeconds
     }

--- a/Pomodoro Timer App/ViewModels/TimerManagerProtocol.swift
+++ b/Pomodoro Timer App/ViewModels/TimerManagerProtocol.swift
@@ -14,6 +14,7 @@ protocol TimerManagerProtocol: ObservableObject {
     var isTimerRunning: Bool { get set }
     var hasStartedSession: Bool { get set }
     var hideTimerButtons: Bool { get set }
+    var progress: Float { get set }
 
     func startTimer()
     func stopTimer()

--- a/Pomodoro Timer App/Views/SettingsView.swift
+++ b/Pomodoro Timer App/Views/SettingsView.swift
@@ -178,11 +178,13 @@ struct SettingsView: View {
                     .foregroundColor(.secondary)
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Button("Save") {
-                        viewModel.saveSettings()
+                    if viewModel.hasChanges {
+                        Button("Save") {
+                            viewModel.saveSettings()
+                        }
+                        .foregroundColor(Color.blue)
+                        .padding()
                     }
-                    .foregroundColor(Color.blue)
-                    .padding()
                 }
             }
             .onAppear {

--- a/Pomodoro Timer App/Views/TimerView.swift
+++ b/Pomodoro Timer App/Views/TimerView.swift
@@ -25,6 +25,7 @@ struct TimerView: View {
                     header
                     Spacer()
                     timerContainer
+                    progressBar
                     Spacer()
                     roundsEmojisView
                     if !timerManager.hideTimerButtons {
@@ -79,7 +80,24 @@ struct TimerView: View {
         .padding(.top, UIConstants.topPadding)
         .padding(.horizontal, UIConstants.horizontalPadding)
     }
-    
+
+    private var progressBar: some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(Color.theme.invertedPrimary.opacity(0.3))
+
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(Color.theme.greenAccent)
+                    .frame(width: geometry.size.width * CGFloat(timerManager.progress))
+                    .animation(.linear(duration: 0.3), value: timerManager.progress)
+            }
+        }
+        .frame(maxWidth: UIConstants.maxTimerContainerWidth * 0.8, maxHeight: 6)
+        .padding(.top, 8)
+        .padding(.horizontal, UIConstants.horizontalPadding)
+    }
+
     private var roundsEmojisView: some View {
         RoundsEmojisView(
             rounds: timerManager.timer.rounds,

--- a/Pomodoro Timer AppTests/Mocks/MockTimerManager.swift
+++ b/Pomodoro Timer AppTests/Mocks/MockTimerManager.swift
@@ -22,6 +22,7 @@ class MockTimerManager: ObservableObject {
     var hasStartedSession = false
     var hideTimerButtons = false
     var isFocusInterval = true
+    var progress: Float = 0
     var startTimerCallCount = 0
     var stopTimerCallCount = 0
     var resetTimerCallCount = 0


### PR DESCRIPTION
## Summary
- **Timer progress bar**: Adds a thin green progress bar directly below the timer square that fills from left to right as the timer counts down. Width is inset ~10% on each side to align with the square's rounded corners.
- **Progress resume fix**: Preserves `totalTimeInSeconds` when resuming so the progress bar doesn't reset when pausing or opening/closing settings mid-session.
- **Conditional Save button**: The Save button in settings is now hidden until the user has actually changed a value, preventing no-op saves.

## Test plan
- [ ] Start a focus timer and verify the green bar fills smoothly from left to right
- [ ] Pause and resume — progress bar should continue from where it left off
- [ ] Open and close settings while the timer is running — progress bar should not reset
- [ ] Reset the timer — progress bar should return to empty
- [ ] Verify the progress bar resets between rounds/breaks
- [ ] Open settings without changing anything — Save button should not appear
- [ ] Change any setting — Save button should appear
- [ ] Revert the change back to the original value — Save button should disappear again

🤖 Generated with [Claude Code](https://claude.com/claude-code)