### PR TITLE
Add tabbed navigation, metrics tracker, and settings restyle

### DIFF
--- a/Pomodoro Timer App.xcodeproj/project.pbxproj
+++ b/Pomodoro Timer App.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		2190D66C2B12F36700F31BDB /* ColorSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21258FAC2B09B01000C673D4 /* ColorSettings.swift */; };
 		2190D66D2B12F3DB00F31BDB /* DarkLightModeButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211E6F5E2B0C3523000E1076 /* DarkLightModeButtonStyle.swift */; };
 		2190D6722B12F8CD00F31BDB /* MockTimerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2190D6712B12F8CD00F31BDB /* MockTimerModel.swift */; };
+		219A3B082F6FB93F00A222E5 /* MetricsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219A3B072F6FB93F00A222E5 /* MetricsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -138,6 +139,7 @@
 		21473EFC2B074948002ECDC6 /* TimerButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerButtonStyle.swift; sourceTree = "<group>"; };
 		2190D6682B12F29200F31BDB /* MockSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSettingsView.swift; sourceTree = "<group>"; };
 		2190D6712B12F8CD00F31BDB /* MockTimerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTimerModel.swift; sourceTree = "<group>"; };
+		219A3B072F6FB93F00A222E5 /* MetricsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -287,6 +289,7 @@
 				2132F33F2B081FBD0012BA04 /* SettingsView.swift */,
 				21258FEA2B0B120300C673D4 /* TimerCompletedView.swift */,
 				212AD68C2B2592DB00C59A7A /* EmojiGridView.swift */,
+				219A3B072F6FB93F00A222E5 /* MetricsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -525,6 +528,7 @@
 				210841B92B15B92500A6BDDC /* FontStyles.swift in Sources */,
 				21258FAD2B09B01000C673D4 /* ColorSettings.swift in Sources */,
 				21473EFD2B074948002ECDC6 /* TimerButtonStyle.swift in Sources */,
+				219A3B082F6FB93F00A222E5 /* MetricsView.swift in Sources */,
 				210841B52B157BBE00A6BDDC /* TimerActivityManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Pomodoro Timer App/ContentView.swift
+++ b/Pomodoro Timer App/ContentView.swift
@@ -7,14 +7,27 @@
 
 import SwiftUI
 
+enum Tab {
+    case timer
+    case metrics
+    case settings
+}
+
 struct ContentView: View {
     @State private var colorMode: AppColorMode
+    @State private var selectedTab: Tab = .timer
+    @State private var focusEmoji: String
+    @State private var breakEmoji: String
+    @State private var longBreakEmoji: String
 
     @StateObject private var timerManager: TimerManager
 
     init() {
         let settings = SharedUserDefaults.shared.getSettings()
         _colorMode = State(initialValue: settings.colorMode)
+        _focusEmoji = State(initialValue: settings.focusEmoji)
+        _breakEmoji = State(initialValue: settings.breakEmoji)
+        _longBreakEmoji = State(initialValue: settings.longBreakEmoji)
         _timerManager = StateObject(wrappedValue: TimerManager(
             timer: DefaultTimer(
                 rounds: settings.rounds,
@@ -29,8 +42,34 @@ struct ContentView: View {
     }
 
     var body: some View {
-        TimerView(colorMode: $colorMode)
-            .environmentObject(timerManager)
+        TabView(selection: $selectedTab) {
+            TimerView(
+                colorMode: $colorMode,
+                focusEmoji: $focusEmoji,
+                breakEmoji: $breakEmoji,
+                longBreakEmoji: $longBreakEmoji
+            )
+            .tabItem { Label("Timer", systemImage: "timer") }
+            .tag(Tab.timer)
+
+            MetricsView()
+                .tabItem { Label("Metrics", systemImage: "chart.dots.scatter") }
+                .tag(Tab.metrics)
+
+            SettingsView(
+                colorMode: $colorMode,
+                focusEmoji: $focusEmoji,
+                breakEmoji: $breakEmoji,
+                longBreakEmoji: $longBreakEmoji,
+                timerManager: timerManager,
+                selectedTab: $selectedTab
+            )
+            .tabItem { Label("Settings", systemImage: "gearshape") }
+            .tag(Tab.settings)
+        }
+        .tint(Color.theme.invertedPrimary)
+        .environmentObject(timerManager)
+        .modifier(ColorModeViewModifier(mode: colorMode))
     }
 }
 

--- a/Pomodoro Timer App/ViewModels/DailyStatsManager.swift
+++ b/Pomodoro Timer App/ViewModels/DailyStatsManager.swift
@@ -10,15 +10,29 @@ class DailyStatsManager: ObservableObject {
 
     private let userDefaults: UserDefaults
     private let completedRoundsKey = "dailyCompletedRounds"
+    private let completedSeriesKey = "dailyCompletedSeries"
     private let lastDateKey = "dailyStatsDate"
     private let dailyGoalKey = "dailyFocusGoal"
+    private let historyKey = "dailyStatsHistory"
+    private let seriesHistoryKey = "dailySeriesHistory"
+
+    private static let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
 
     @Published var completedRoundsToday: Int = 0
+    @Published var completedSeriesToday: Int = 0
     @Published var dailyGoal: Int = 8
+    @Published var dailyHistory: [String: Int] = [:]
+    @Published var seriesHistory: [String: Int] = [:]
 
     init() {
         self.userDefaults = UserDefaults(suiteName: "group.com.pomodoro-timer") ?? .standard
         self.dailyGoal = userDefaults.object(forKey: dailyGoalKey) != nil ? userDefaults.integer(forKey: dailyGoalKey) : 8
+        self.dailyHistory = (userDefaults.dictionary(forKey: historyKey) as? [String: Int]) ?? [:]
+        self.seriesHistory = (userDefaults.dictionary(forKey: seriesHistoryKey) as? [String: Int]) ?? [:]
         resetIfNewDay()
     }
 
@@ -26,11 +40,76 @@ class DailyStatsManager: ObservableObject {
         resetIfNewDay()
         completedRoundsToday += 1
         userDefaults.set(completedRoundsToday, forKey: completedRoundsKey)
+        saveTodayToHistory()
+    }
+
+    func recordCompletedSeries() {
+        resetIfNewDay()
+        completedSeriesToday += 1
+        userDefaults.set(completedSeriesToday, forKey: completedSeriesKey)
+        saveTodaySeriesToHistory()
     }
 
     func setDailyGoal(_ goal: Int) {
         dailyGoal = goal
         userDefaults.set(goal, forKey: dailyGoalKey)
+    }
+
+    func roundsCompleted(on date: Date) -> Int {
+        let key = Self.dateFormatter.string(from: date)
+        if Calendar.current.isDateInToday(date) {
+            return completedRoundsToday
+        }
+        return dailyHistory[key] ?? 0
+    }
+
+    func seriesCompleted(on date: Date) -> Int {
+        let key = Self.dateFormatter.string(from: date)
+        if Calendar.current.isDateInToday(date) {
+            return completedSeriesToday
+        }
+        return seriesHistory[key] ?? 0
+    }
+
+    func didCompleteSeries(on date: Date) -> Bool {
+        return seriesCompleted(on: date) > 0
+    }
+
+    func currentStreak() -> Int {
+        let calendar = Calendar.current
+        var streak = 0
+        var date = calendar.startOfDay(for: Date())
+
+        // Check today first
+        if didCompleteSeries(on: date) {
+            streak += 1
+        } else {
+            return 0
+        }
+
+        // Walk backwards
+        while true {
+            guard let previousDay = calendar.date(byAdding: .day, value: -1, to: date) else { break }
+            date = previousDay
+            if didCompleteSeries(on: date) {
+                streak += 1
+            } else {
+                break
+            }
+        }
+        return streak
+    }
+
+    private func saveTodayToHistory() {
+        let key = Self.dateFormatter.string(from: Date())
+        dailyHistory[key] = completedRoundsToday
+        userDefaults.set(dailyHistory, forKey: historyKey)
+    }
+
+    private func saveTodaySeriesToHistory() {
+        let key = Self.dateFormatter.string(from: Date())
+        seriesHistory[key] = completedSeriesToday
+        userDefaults.set(seriesHistory, forKey: seriesHistoryKey)
     }
 
     private func resetIfNewDay() {
@@ -39,11 +118,28 @@ class DailyStatsManager: ObservableObject {
         let lastDay = Calendar.current.startOfDay(for: lastDate)
 
         if today != lastDay {
+            // Save yesterday's final counts to history before resetting
+            if lastDay != Calendar.current.startOfDay(for: .distantPast) {
+                let lastKey = Self.dateFormatter.string(from: lastDay)
+                let lastRounds = userDefaults.integer(forKey: completedRoundsKey)
+                if dailyHistory[lastKey] == nil || lastRounds > (dailyHistory[lastKey] ?? 0) {
+                    dailyHistory[lastKey] = lastRounds
+                    userDefaults.set(dailyHistory, forKey: historyKey)
+                }
+                let lastSeries = userDefaults.integer(forKey: completedSeriesKey)
+                if seriesHistory[lastKey] == nil || lastSeries > (seriesHistory[lastKey] ?? 0) {
+                    seriesHistory[lastKey] = lastSeries
+                    userDefaults.set(seriesHistory, forKey: seriesHistoryKey)
+                }
+            }
             completedRoundsToday = 0
+            completedSeriesToday = 0
             userDefaults.set(0, forKey: completedRoundsKey)
+            userDefaults.set(0, forKey: completedSeriesKey)
             userDefaults.set(today, forKey: lastDateKey)
         } else {
             completedRoundsToday = userDefaults.integer(forKey: completedRoundsKey)
+            completedSeriesToday = userDefaults.integer(forKey: completedSeriesKey)
         }
     }
 }

--- a/Pomodoro Timer App/ViewModels/SettingsViewModel.swift
+++ b/Pomodoro Timer App/ViewModels/SettingsViewModel.swift
@@ -10,7 +10,6 @@ import Foundation
 
 class SettingsViewModel: ObservableObject {
     @Binding var colorMode: AppColorMode
-    @Binding var showingSettings: Bool
     @Binding var focusEmoji: String
     @Binding var breakEmoji: String
     @Binding var longBreakEmoji: String
@@ -37,9 +36,8 @@ class SettingsViewModel: ObservableObject {
     // Shared UserDefaults instance
     let sharedUserDefaults: SharedUserDefaults
 
-    init(colorMode: Binding<AppColorMode>, showingSettings: Binding<Bool>, focusEmoji: Binding<String>, breakEmoji: Binding<String>, longBreakEmoji: Binding<String>, timerManager: TimerManager) {
+    init(colorMode: Binding<AppColorMode>, focusEmoji: Binding<String>, breakEmoji: Binding<String>, longBreakEmoji: Binding<String>, timerManager: TimerManager) {
         self._colorMode = colorMode
-        self._showingSettings = showingSettings
         self._focusEmoji = focusEmoji
         self._breakEmoji = breakEmoji
         self._longBreakEmoji = longBreakEmoji
@@ -93,8 +91,7 @@ class SettingsViewModel: ObservableObject {
         
         UIApplication.shared.isIdleTimerDisabled = tempPreventDisplaySleep
         colorMode = tempColorMode
-        $showingSettings.wrappedValue = false
-        
+
         focusEmoji = tempFocusEmoji
         breakEmoji = tempBreakEmoji
         longBreakEmoji = tempLongBreakEmoji

--- a/Pomodoro Timer App/ViewModels/SoundManager.swift
+++ b/Pomodoro Timer App/ViewModels/SoundManager.swift
@@ -17,21 +17,137 @@ class SoundManager {
         case chime = "Chime"
         case bell = "Bell"
         case ding = "Ding"
+        case radar = "Radar"
+        case apex = "Apex"
+        case beacon = "Beacon"
+        case bulletin = "Bulletin"
+        case bamboo = "Bamboo"
+        case chord = "Chord"
+        case circles = "Circles"
+        case complete = "Complete"
+        case hello = "Hello"
+        case input = "Input"
+        case keys = "Keys"
+        case note = "Note"
+        case popcorn = "Popcorn"
+        case pulse = "Pulse"
+        case synth = "Synth"
+        case alert = "Alert"
+        case anticipate = "Anticipate"
+        case bloom = "Bloom"
+        case calypso = "Calypso"
+        case choo = "Choo Choo"
+        case descent = "Descent"
+        case fanfare = "Fanfare"
+        case ladder = "Ladder"
+        case minuet = "Minuet"
+        case newsFlash = "News Flash"
+        case sherwood = "Sherwood Forest"
+        case spell = "Spell"
+        case suspense = "Suspense"
+        case telegraph = "Telegraph"
+        case tiptoes = "Tiptoes"
+        case typewriters = "Typewriters"
+        case update = "Update"
         case none = "None"
+
+        var soundFileName: String? {
+            switch self {
+            case .chime: return nil    // uses system sound ID
+            case .bell: return nil     // uses system sound ID
+            case .ding: return nil     // uses system sound ID
+            case .radar: return "radar"
+            case .apex: return "apex"
+            case .beacon: return "beacon"
+            case .bulletin: return "bulletin"
+            case .bamboo: return "bamboo"
+            case .chord: return "chord"
+            case .circles: return "circles"
+            case .complete: return "complete"
+            case .hello: return "hello"
+            case .input: return "input"
+            case .keys: return "keys"
+            case .note: return "note"
+            case .popcorn: return "popcorn"
+            case .pulse: return "pulse"
+            case .synth: return "synth"
+            case .alert: return "alert"
+            case .anticipate: return "anticipate"
+            case .bloom: return "bloom"
+            case .calypso: return "calypso"
+            case .choo: return "choo-choo"
+            case .descent: return "descent"
+            case .fanfare: return "fanfare"
+            case .ladder: return "ladder"
+            case .minuet: return "minuet"
+            case .newsFlash: return "news-flash"
+            case .sherwood: return "sherwood-forest"
+            case .spell: return "spell"
+            case .suspense: return "suspense"
+            case .telegraph: return "telegraph"
+            case .tiptoes: return "tiptoes"
+            case .typewriters: return "typewriters"
+            case .update: return "update"
+            case .none: return nil
+            }
+        }
 
         var systemSoundID: SystemSoundID? {
             switch self {
             case .chime: return 1025
             case .bell: return 1013
             case .ding: return 1057
-            case .none: return nil
+            default: return nil
             }
         }
     }
 
     func playCompletionSound(_ sound: CompletionSound) {
-        guard let soundID = sound.systemSoundID else { return }
-        AudioServicesPlaySystemSound(soundID)
+        // Stop any currently playing sound
+        audioPlayer?.stop()
+        audioPlayer = nil
+
+        // Try system sound ID first (for legacy chime/bell/ding)
+        if let soundID = sound.systemSoundID {
+            AudioServicesPlaySystemSound(soundID)
+            return
+        }
+
+        // Try file-based sound from system UISounds directory
+        guard let fileName = sound.soundFileName else { return }
+
+        let searchPaths = [
+            "/System/Library/Audio/UISounds/\(fileName).caf",
+            "/System/Library/Audio/UISounds/New/\(fileName).caf",
+            "/System/Library/Audio/UISounds/nano/\(fileName).caf",
+            "/System/Library/Audio/UISounds/3rd_party/\(fileName).caf"
+        ]
+
+        for path in searchPaths {
+            let url = URL(fileURLWithPath: path)
+            if FileManager.default.fileExists(atPath: path) {
+                do {
+                    audioPlayer = try AVAudioPlayer(contentsOf: url)
+                    audioPlayer?.play()
+                    return
+                } catch {
+                    continue
+                }
+            }
+        }
+
+        // Fallback: try creating a system sound from the path
+        if let url = CFURLCreateWithFileSystemPath(nil, "/System/Library/Audio/UISounds/\(fileName).caf" as CFString, .cfurlposixPathStyle, false) {
+            var soundID: SystemSoundID = 0
+            AudioServicesCreateSystemSoundID(url, &soundID)
+            if soundID != 0 {
+                AudioServicesPlaySystemSound(soundID)
+                // Dispose after a delay to allow playback
+                DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                    AudioServicesDisposeSystemSoundID(soundID)
+                }
+            }
+        }
     }
 
     func triggerHaptic() {

--- a/Pomodoro Timer App/ViewModels/TimerManager.swift
+++ b/Pomodoro Timer App/ViewModels/TimerManager.swift
@@ -233,6 +233,7 @@ class TimerManager: TimerManagerProtocol, ObservableObject {
                 notificationBody = "Ready to focus? \(timer.rounds - completedRounds) rounds to go!"
 
             } else { // End of the last break
+                DailyStatsManager.shared.recordCompletedSeries()
 
                 notificationTitle = "Pomodoro Session Complete"
                 notificationBody = "Congrats! You made it to the end of your pomodoro session."

--- a/Pomodoro Timer App/Views/MetricsView.swift
+++ b/Pomodoro Timer App/Views/MetricsView.swift
@@ -1,0 +1,374 @@
+//
+//  MetricsView.swift
+//  Pomodoro Timer App
+//
+
+import SwiftUI
+
+struct MetricsView: View {
+    @ObservedObject private var statsManager = DailyStatsManager.shared
+
+    private let dotSpacing: CGFloat = 5
+    private let horizontalPadding: CGFloat = 16
+
+    @State private var selectedFilter: MetricsFilter = .year
+    @State private var loadedWeeks = 12
+    @State private var loadedMonths = 6
+    @State private var loadedYears = 1
+    @State private var contentWidth: CGFloat = 0
+    @State private var isLoadingMore = false
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    filterBar
+                        .background(
+                            GeometryReader { geometry in
+                                Color.clear
+                                    .onAppear {
+                                        contentWidth = geometry.size.width
+                                    }
+                                    .onChange(of: geometry.size.width) {
+                                        contentWidth = geometry.size.width
+                                    }
+                            }
+                        )
+                    dotContent
+                }
+                .padding(.horizontal, horizontalPadding)
+                .padding(.vertical)
+            }
+            .background(Color.theme.primaryColor.ignoresSafeArea())
+            .navigationTitle("Metrics")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+
+    // MARK: - Layout Calculations
+
+    private var columns: Int {
+        selectedFilter == .year ? 14 : 7
+    }
+
+    private var dotSize: CGFloat {
+        guard contentWidth > 0 else { return 10 }
+        return floor((contentWidth - CGFloat(columns - 1) * dotSpacing) / CGFloat(columns))
+    }
+
+    private var gridColumns: [GridItem] {
+        Array(
+            repeating: GridItem(.fixed(dotSize), spacing: dotSpacing),
+            count: columns
+        )
+    }
+
+    // MARK: - Filter Bar
+
+    private var filterBar: some View {
+        HStack(spacing: 0) {
+            ForEach(MetricsFilter.allCases, id: \.self) { filter in
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        selectedFilter = filter
+                    }
+                } label: {
+                    Text(filter.label)
+                        .font(.subheadline)
+                        .fontWeight(selectedFilter == filter ? .semibold : .regular)
+                        .foregroundColor(selectedFilter == filter ? Color.theme.primaryColor : Color.theme.invertedPrimary.opacity(0.6))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                        .background(
+                            selectedFilter == filter
+                                ? Color.theme.invertedPrimary
+                                : Color.clear
+                        )
+                        .cornerRadius(8)
+                }
+            }
+        }
+        .padding(3)
+        .background(Color.theme.invertedPrimary.opacity(0.1))
+        .cornerRadius(10)
+    }
+
+    // MARK: - Dot Content
+
+    @ViewBuilder
+    private var dotContent: some View {
+        if contentWidth > 0 {
+            switch selectedFilter {
+            case .week:
+                weekView
+            case .month:
+                monthView
+            case .year:
+                yearView
+            }
+        }
+    }
+
+    // MARK: - Week View
+
+    private var weekView: some View {
+        let weeks = generateWeeks(count: loadedWeeks)
+
+        return LazyVStack(alignment: .leading, spacing: 16) {
+            ForEach(weeks) { week in
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(week.label)
+                        .font(.caption)
+                        .foregroundColor(Color.theme.roundSubtitle)
+
+                    LazyVGrid(columns: gridColumns, alignment: .leading, spacing: dotSpacing) {
+                        ForEach(week.days) { day in
+                            dotView(for: day)
+                        }
+                    }
+                }
+            }
+
+            if loadedWeeks < 156 {
+                scrollSentinel {
+                    loadedWeeks = min(loadedWeeks + 12, 156)
+                }
+            }
+        }
+    }
+
+    // MARK: - Month View
+
+    private var monthView: some View {
+        let months = generateMonthGroups(count: loadedMonths)
+
+        return LazyVStack(alignment: .leading, spacing: 16) {
+            ForEach(months) { month in
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(month.label)
+                        .font(.caption)
+                        .foregroundColor(Color.theme.roundSubtitle)
+
+                    LazyVGrid(columns: gridColumns, alignment: .leading, spacing: dotSpacing) {
+                        ForEach(month.days) { day in
+                            dotView(for: day)
+                        }
+                    }
+                }
+            }
+
+            if loadedMonths < 36 {
+                scrollSentinel {
+                    loadedMonths = min(loadedMonths + 6, 36)
+                }
+            }
+        }
+    }
+
+    // MARK: - Year View
+
+    private var yearView: some View {
+        let years = generateYearGroups(count: loadedYears)
+
+        return LazyVStack(alignment: .leading, spacing: 20) {
+            ForEach(years) { year in
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(year.label)
+                        .font(.caption)
+                        .foregroundColor(Color.theme.roundSubtitle)
+
+                    LazyVGrid(columns: gridColumns, alignment: .leading, spacing: dotSpacing) {
+                        ForEach(year.days) { day in
+                            dotView(for: day)
+                        }
+                    }
+                }
+            }
+
+            if loadedYears < 3 {
+                scrollSentinel {
+                    loadedYears = min(loadedYears + 1, 3)
+                }
+            }
+        }
+    }
+
+    // MARK: - Shared Components
+
+    private func scrollSentinel(action: @escaping () -> Void) -> some View {
+        Color.clear
+            .frame(height: 1)
+            .onAppear {
+                guard !isLoadingMore else { return }
+                isLoadingMore = true
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    action()
+                    isLoadingMore = false
+                }
+            }
+    }
+
+    @ViewBuilder
+    private func dotView(for day: CalendarDay) -> some View {
+        if day.isFuture {
+            Circle()
+                .fill(Color.theme.grayAccent.opacity(0.25))
+                .frame(width: dotSize, height: dotSize)
+        } else {
+            let completed = statsManager.didCompleteSeries(on: day.date)
+            if completed {
+                Text("🏆")
+                    .font(.system(size: dotSize * 0.8))
+                    .frame(width: dotSize, height: dotSize)
+            } else {
+                Circle()
+                    .fill(Color.theme.grayAccent.opacity(0.3))
+                    .frame(width: dotSize, height: dotSize)
+                    .overlay(
+                        day.isToday
+                            ? Circle().stroke(Color.theme.invertedPrimary, lineWidth: 1.5)
+                            : nil
+                    )
+            }
+        }
+    }
+
+    // MARK: - Data Generation
+
+    private func generateWeeks(count: Int) -> [DotGroup] {
+        let calendar = Calendar.current
+        let today = Date()
+        var groups: [DotGroup] = []
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d"
+
+        for weekOffset in 0..<count {
+            guard let weekEnd = calendar.date(byAdding: .weekOfYear, value: -weekOffset, to: today) else { continue }
+            guard let weekStart = calendar.date(byAdding: .day, value: -6, to: weekEnd) else { continue }
+
+            let endFormatter = DateFormatter()
+            endFormatter.dateFormat = "MMM d"
+            let label = weekOffset == 0 ? "This Week" : "\(formatter.string(from: weekStart)) – \(endFormatter.string(from: weekEnd))"
+
+            var days: [CalendarDay] = []
+            for dayOffset in 0..<7 {
+                guard let date = calendar.date(byAdding: .day, value: dayOffset, to: weekStart) else { continue }
+                let isToday = calendar.isDateInToday(date)
+                let isFuture = date > today && !isToday
+                days.append(CalendarDay(date: date, isToday: isToday, isFuture: isFuture))
+            }
+
+            groups.append(DotGroup(label: label, days: days))
+        }
+
+        return groups
+    }
+
+    private func generateMonthGroups(count: Int) -> [DotGroup] {
+        let calendar = Calendar.current
+        let today = Date()
+        var groups: [DotGroup] = []
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM yyyy"
+
+        for offset in 0..<count {
+            guard let monthDate = calendar.date(byAdding: .month, value: -offset, to: today) else { continue }
+            let components = calendar.dateComponents([.year, .month], from: monthDate)
+            guard let year = components.year, let month = components.month else { continue }
+            guard let startOfMonth = calendar.date(from: components) else { continue }
+            guard let range = calendar.range(of: .day, in: .month, for: startOfMonth) else { continue }
+
+            let label = formatter.string(from: startOfMonth)
+            var days: [CalendarDay] = []
+
+            for day in range {
+                var dayComponents = DateComponents()
+                dayComponents.year = year
+                dayComponents.month = month
+                dayComponents.day = day
+                guard let date = calendar.date(from: dayComponents) else { continue }
+                let isToday = calendar.isDateInToday(date)
+                let isFuture = date > today && !isToday
+                days.append(CalendarDay(date: date, isToday: isToday, isFuture: isFuture))
+            }
+
+            groups.append(DotGroup(label: label, days: days))
+        }
+
+        return groups
+    }
+
+    private func generateYearGroups(count: Int) -> [DotGroup] {
+        let calendar = Calendar.current
+        let today = Date()
+        let currentYear = calendar.component(.year, from: today)
+        var groups: [DotGroup] = []
+
+        for yearOffset in 0..<count {
+            let year = currentYear - yearOffset
+            let label = "\(year)"
+
+            var startComponents = DateComponents()
+            startComponents.year = year
+            startComponents.month = 1
+            startComponents.day = 1
+            guard let startOfYear = calendar.date(from: startComponents) else { continue }
+
+            var endComponents = DateComponents()
+            endComponents.year = year
+            endComponents.month = 12
+            endComponents.day = 31
+            guard let endOfYear = calendar.date(from: endComponents) else { continue }
+
+            var days: [CalendarDay] = []
+            var currentDate = startOfYear
+
+            while currentDate <= endOfYear {
+                let isToday = calendar.isDateInToday(currentDate)
+                let isFuture = currentDate > today && !isToday
+                days.append(CalendarDay(date: currentDate, isToday: isToday, isFuture: isFuture))
+                guard let next = calendar.date(byAdding: .day, value: 1, to: currentDate) else { break }
+                currentDate = next
+            }
+
+            groups.append(DotGroup(label: label, days: days))
+        }
+
+        return groups
+    }
+}
+
+// MARK: - Filter Enum
+
+enum MetricsFilter: CaseIterable {
+    case week
+    case month
+    case year
+
+    var label: String {
+        switch self {
+        case .week: return "Week"
+        case .month: return "Month"
+        case .year: return "Year"
+        }
+    }
+}
+
+// MARK: - Models
+
+private struct DotGroup: Identifiable {
+    let id = UUID()
+    let label: String
+    let days: [CalendarDay]
+}
+
+private struct CalendarDay: Identifiable {
+    let id = UUID()
+    let date: Date
+    let isToday: Bool
+    let isFuture: Bool
+}
+
+#Preview {
+    MetricsView()
+}

--- a/Pomodoro Timer App/Views/SettingsView.swift
+++ b/Pomodoro Timer App/Views/SettingsView.swift
@@ -10,26 +10,25 @@ import SwiftUI
 struct SettingsView: View {
     @StateObject var viewModel: SettingsViewModel
     @EnvironmentObject var timerManager: TimerManager
-    
+
     @Binding var colorMode: AppColorMode
-    @Binding var showingSettings: Bool
     @Binding var focusEmoji: String
     @Binding var breakEmoji: String
     @Binding var longBreakEmoji: String
-    
-    @State private var isTimerRunningWhenSettingsOpened = false
+    @Binding var selectedTab: Tab
+
     @State var showingFocusEmojiGrid = false
     @State var showingBreakEmojiGrid = false
     @State var showingLongBreakEmojiGrid = false
     @State private var showingResetConfirmation = false
 
-    init(colorMode: Binding<AppColorMode>, showingSettings: Binding<Bool>, focusEmoji: Binding<String>, breakEmoji: Binding<String>, longBreakEmoji: Binding<String>, timerManager: TimerManager) {
-        self._viewModel = StateObject(wrappedValue: SettingsViewModel(colorMode: colorMode, showingSettings: showingSettings, focusEmoji: focusEmoji, breakEmoji: breakEmoji, longBreakEmoji: longBreakEmoji, timerManager: timerManager))
+    init(colorMode: Binding<AppColorMode>, focusEmoji: Binding<String>, breakEmoji: Binding<String>, longBreakEmoji: Binding<String>, timerManager: TimerManager, selectedTab: Binding<Tab>) {
+        self._viewModel = StateObject(wrappedValue: SettingsViewModel(colorMode: colorMode, focusEmoji: focusEmoji, breakEmoji: breakEmoji, longBreakEmoji: longBreakEmoji, timerManager: timerManager))
         self._colorMode = colorMode
-        self._showingSettings = showingSettings
         self._focusEmoji = focusEmoji
         self._breakEmoji = breakEmoji
         self._longBreakEmoji = longBreakEmoji
+        self._selectedTab = selectedTab
     }
 
     var body: some View {
@@ -37,35 +36,11 @@ struct SettingsView: View {
             Form {
                 Section(header: Text("Pomodoro Timer")
                     .font(.timerSubtitle)) {
-                        Picker("Rounds", selection: $viewModel.tempRounds) {
-                        ForEach(1...10, id: \.self) { round in
-                            Text("\(round)").tag(round)
-                        }
-                    }
-
-                        Picker("Focus Session", selection: $viewModel.tempFocusSessionMinutes) {
-                        ForEach(1...60, id: \.self) { minute in
-                            Text("\(minute) min").tag(minute)
-                        }
-                    }
-
-                        Picker("Short Break", selection: $viewModel.tempShortBreakMinutes) {
-                        ForEach(1...20, id: \.self) { minute in
-                            Text("\(minute) min").tag(minute)
-                        }
-                    }
-                    
-                        Picker("Long Break", selection: $viewModel.tempLongBreakMinutes) {
-                        ForEach(1...45, id: \.self) { minute in
-                            Text("\(minute) min").tag(minute)
-                        }
-                    }
-
-                        Picker("Long Break Every", selection: $viewModel.tempLongBreakInterval) {
-                        ForEach(2...10, id: \.self) { interval in
-                            Text("\(interval) rounds").tag(interval)
-                        }
-                    }
+                    ExpandableWheelPicker(title: "Rounds", suffix: "", selection: $viewModel.tempRounds, range: 1...10)
+                    ExpandableWheelPicker(title: "Focus Session", suffix: "min", selection: $viewModel.tempFocusSessionMinutes, range: 1...60)
+                    ExpandableWheelPicker(title: "Short Break", suffix: "min", selection: $viewModel.tempShortBreakMinutes, range: 1...20)
+                    ExpandableWheelPicker(title: "Long Break", suffix: "min", selection: $viewModel.tempLongBreakMinutes, range: 1...45)
+                    ExpandableWheelPicker(title: "Long Break Every", suffix: "rounds", selection: $viewModel.tempLongBreakInterval, range: 2...10)
                 }
 
                 Section(header: Text("Appearance")
@@ -76,10 +51,12 @@ struct SettingsView: View {
                         Text("Light").tag(AppColorMode.light)
                         Text("Dark").tag(AppColorMode.dark)
                     }
-                        
+                    .tint(Color.theme.invertedPrimary)
+
                     Button(action: { showingFocusEmojiGrid.toggle() }) {
                         HStack {
                             Text("Focus Emoji")
+                                .foregroundColor(.primary)
                             Spacer()
                             Text(viewModel.tempFocusEmoji)
                         }
@@ -87,10 +64,11 @@ struct SettingsView: View {
                     .sheet(isPresented: $showingFocusEmojiGrid) {
                         EmojiGridView(colorMode: $viewModel.tempColorMode, title: "Select Focus Emoji", emojiSelection: $viewModel.tempFocusEmoji, isPresented: $showingFocusEmojiGrid)
                     }
-                        
+
                     Button(action: { showingBreakEmojiGrid.toggle() }) {
                         HStack {
                             Text("Break Emoji")
+                                .foregroundColor(.primary)
                             Spacer()
                             Text(viewModel.tempBreakEmoji)
                         }
@@ -102,6 +80,7 @@ struct SettingsView: View {
                     Button(action: { showingLongBreakEmojiGrid.toggle() }) {
                         HStack {
                             Text("Long Break Emoji")
+                                .foregroundColor(.primary)
                             Spacer()
                             Text(viewModel.tempLongBreakEmoji)
                         }
@@ -121,17 +100,15 @@ struct SettingsView: View {
                             .foregroundColor(.secondary)
                     }
 
-                    Picker("Daily Focus Goal", selection: $viewModel.tempDailyGoal) {
-                        ForEach(1...20, id: \.self) { goal in
-                            Text("\(goal) rounds").tag(goal)
-                        }
-                    }
+                    ExpandableWheelPicker(title: "Daily Focus Goal", suffix: "rounds", selection: $viewModel.tempDailyGoal, range: 1...20)
                 }
 
                 Section(header: Text("Auto-Start")
                     .font(.timerSubtitle)) {
                     Toggle("Auto-Start Breaks", isOn: $viewModel.tempAutoStartBreaks)
+                        .tint(Color.theme.greenAccent)
                     Toggle("Auto-Start Focus Sessions", isOn: $viewModel.tempAutoStartFocus)
+                        .tint(Color.theme.greenAccent)
                 }
 
                 Section(header: Text("Sound & Haptics")
@@ -141,16 +118,20 @@ struct SettingsView: View {
                             Text(sound.rawValue).tag(sound)
                         }
                     }
-                    .onChange(of: viewModel.tempCompletionSound) { newSound in
-                        SoundManager.shared.playCompletionSound(newSound)
+                    .tint(Color.theme.invertedPrimary)
+                    .onChange(of: viewModel.tempCompletionSound) {
+                        SoundManager.shared.playCompletionSound(viewModel.tempCompletionSound)
                     }
                     Toggle("Haptic Feedback", isOn: $viewModel.tempHapticFeedback)
+                        .tint(Color.theme.greenAccent)
                 }
 
                 Section(header: Text("Utilities")
                     .font(.timerSubtitle)) {
                     Toggle("Allow Notifications", isOn: $viewModel.tempAllowNotifications)
+                        .tint(Color.theme.greenAccent)
                     Toggle("Prevent Display Going to Sleep", isOn: $viewModel.tempPreventDisplaySleep)
+                        .tint(Color.theme.greenAccent)
                 }
 
                 Section {
@@ -170,17 +151,14 @@ struct SettingsView: View {
                     }
                 }
             }
+            .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button("Cancel") {
-                        showingSettings = false
-                    }
-                    .foregroundColor(.secondary)
-                }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     if viewModel.hasChanges {
                         Button("Save") {
                             viewModel.saveSettings()
+                            selectedTab = .timer
                         }
                         .foregroundColor(Color.blue)
                         .padding()
@@ -189,17 +167,50 @@ struct SettingsView: View {
             }
             .onAppear {
                 viewModel.checkNotificationPermission()
-                if timerManager.isTimerRunning {
-                    isTimerRunningWhenSettingsOpened = true
-                    timerManager.stopTimer()
-                }
-            }
-            .onDisappear {
-                if isTimerRunningWhenSettingsOpened {
-                    timerManager.startTimer()
-                }
             }
         }
-        .modifier(ColorModeViewModifier(mode: viewModel.tempColorMode))
+    }
+}
+
+// MARK: - Expandable Wheel Picker
+
+private struct ExpandableWheelPicker: View {
+    let title: String
+    let suffix: String
+    @Binding var selection: Int
+    let range: ClosedRange<Int>
+    @State private var isExpanded = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack {
+                    Text(title)
+                        .foregroundColor(.primary)
+                    Spacer()
+                    Text(suffix.isEmpty ? "\(selection)" : "\(selection) \(suffix)")
+                        .foregroundColor(.secondary)
+                    Image(systemName: "chevron.up")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .rotationEffect(.degrees(isExpanded ? 0 : 180))
+                }
+            }
+
+            if isExpanded {
+                Picker(title, selection: $selection) {
+                    ForEach(Array(range), id: \.self) { value in
+                        Text("\(value)").tag(value)
+                    }
+                }
+                .pickerStyle(.wheel)
+                .frame(height: 120)
+                .clipped()
+            }
+        }
     }
 }

--- a/Pomodoro Timer App/Views/TimerView.swift
+++ b/Pomodoro Timer App/Views/TimerView.swift
@@ -9,20 +9,18 @@ import SwiftUI
 struct TimerView: View {
     @EnvironmentObject var timerManager: TimerManager
     @Binding var colorMode: AppColorMode
-    @State var showingSettings = false
-    @State var focusEmoji: String = "📚"
-    @State var breakEmoji: String = "☕️"
-    @State var longBreakEmoji: String = "🏆"
+    @Binding var focusEmoji: String
+    @Binding var breakEmoji: String
+    @Binding var longBreakEmoji: String
 
     var body: some View {
         ZStack {
             Color.theme.primaryColor.edgesIgnoringSafeArea(.all)
-            
+
             if timerManager.sessionCompleted {
                 TimerCompletedView()
             } else {
                 VStack {
-                    header
                     Spacer()
                     timerContainer
                     progressBar
@@ -35,29 +33,8 @@ struct TimerView: View {
                 }
             }
         }
-        .modifier(ColorModeViewModifier(mode: colorMode))
     }
-    
-    private var header: some View {
-        VStack {
-            HStack {
-                Spacer()
-                Button(action: {
-                    self.showingSettings.toggle()
-                }) {
-                    Image(systemName: "line.horizontal.3")
-                        .imageScale(.medium)
-                        .font(.largeImageIcon)
-                        .padding()
-                }
-            }
-            .sheet(isPresented: $showingSettings) {
-                SettingsView(colorMode: $colorMode, showingSettings: $showingSettings, focusEmoji: $focusEmoji, breakEmoji: $breakEmoji, longBreakEmoji: $longBreakEmoji, timerManager: timerManager)
-            }
-            .foregroundColor(Color.theme.invertedPrimary)
-        }
-    }
-    
+
     private var timerContainer: some View {
         let timerType: String = timerManager.isFocusInterval ? "Focus" : "Break"
         let timeString: String = String(format: "%02dm:%02ds", timerManager.timer.minutes, timerManager.timer.seconds)

--- a/Pomodoro Timer AppTests/Mocks/MockSettingsViewModel.swift
+++ b/Pomodoro Timer AppTests/Mocks/MockSettingsViewModel.swift
@@ -18,9 +18,8 @@ class MockSettingsViewModel: ObservableObject {
 
     public var mockTimerManager: MockTimerManager
     private var originalColorMode: AppColorMode
-    private var showingSettings: Binding<Bool>
 
-    init(colorMode: Binding<AppColorMode>, showingSettings: Binding<Bool>, mockTimerManager: MockTimerManager) {
+    init(colorMode: Binding<AppColorMode>, mockTimerManager: MockTimerManager) {
         self._tempFocusSessionMinutes = Published(initialValue: mockTimerManager.timer.originalMinutes)
         self._tempShortBreakMinutes = Published(initialValue: mockTimerManager.timer.originalBreakMinutes)
         self._tempLongBreakMinutes = Published(initialValue: mockTimerManager.timer.originalLongBreakMinutes)
@@ -29,7 +28,6 @@ class MockSettingsViewModel: ObservableObject {
 
         self.mockTimerManager = mockTimerManager
         self.originalColorMode = colorMode.wrappedValue
-        self.showingSettings = showingSettings
     }
 
     func saveSettings() {
@@ -45,7 +43,6 @@ class MockSettingsViewModel: ObservableObject {
 
         UIApplication.shared.isIdleTimerDisabled = tempPreventDisplaySleep
         originalColorMode = tempColorMode
-        showingSettings.wrappedValue = false
     }
 
     func toggleColorMode() {

--- a/Pomodoro Timer AppTests/SettingsViewTests.swift
+++ b/Pomodoro Timer AppTests/SettingsViewTests.swift
@@ -20,8 +20,7 @@ class SettingsViewTests: XCTestCase {
         mockTimerManager = MockTimerManager(timer: mockTimer)
 
         let colorModeBinding = Binding.constant(AppColorMode.light)
-        let showingSettingsBinding = Binding.constant(true)
-        viewModel = MockSettingsViewModel(colorMode: colorModeBinding, showingSettings: showingSettingsBinding, mockTimerManager: mockTimerManager)
+        viewModel = MockSettingsViewModel(colorMode: colorModeBinding, mockTimerManager: mockTimerManager)
     }
 
     func testSaveSettings_WhenTimerValuesChanged_ShouldResetTimer() {


### PR DESCRIPTION
## Summary
- **Tabbed navigation**: Bottom tab bar with Timer, Metrics, and Settings tabs replacing the previous hamburger menu/sheet pattern
- **Metrics tracker**: New dot calendar view showing daily series completion history with trophy emoji for achieved days, week/month/year filters, and infinite scroll up to 3 years
- **Settings restyle**: Inline expanding wheel pickers replace navigation-push pickers; white tint on pickers, green on toggles; 30+ new completion sounds from iOS system library
- **Series tracking**: Metrics now track completed full pomodoro sessions (all rounds) rather than individual rounds

## Test plan
- [ ] Verify tab bar renders with Timer, Metrics, and Settings tabs
- [ ] Confirm tab selection highlights in white (not green)
- [ ] Test Metrics view: switch between Week, Month, Year filters
- [ ] Verify infinite scroll loads more history in each filter
- [ ] Complete a full pomodoro session and confirm trophy appears in metrics
- [ ] Verify future-date dots are visible in both light and dark mode
- [ ] Test settings wheel pickers expand/collapse correctly
- [ ] Confirm toggles are green, pickers show white tint
- [ ] Preview new completion sounds in settings
- [ ] Verify Save navigates back to Timer tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)